### PR TITLE
TCP voice tunnel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@ Added
 ~~~~~
 
 * Added a noise gate
+* Added tunneling audio through TCP if UDP connection goes down
 
 // Changed
 // ~~~~~~~

--- a/mumd/src/audio.rs
+++ b/mumd/src/audio.rs
@@ -31,7 +31,7 @@ use std::{
 };
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
-use tokio::sync::{watch};
+use tokio::sync::watch;
 
 const SAMPLE_RATE: u32 = 48000;
 

--- a/mumd/src/audio.rs
+++ b/mumd/src/audio.rs
@@ -337,7 +337,7 @@ impl Audio {
         }
     }
 
-    pub fn take_receiver(&mut self) -> Arc<Mutex<Box<dyn Stream<Item = VoicePacket<Serverbound>> + Unpin>>> {
+    pub fn input_receiver(&self) -> Arc<Mutex<Box<dyn Stream<Item = VoicePacket<Serverbound>> + Unpin>>> {
         Arc::clone(&self.input_channel_receiver)
     }
 

--- a/mumd/src/audio.rs
+++ b/mumd/src/audio.rs
@@ -76,7 +76,7 @@ pub struct Audio {
     _output_stream: cpal::Stream,
     _input_stream: cpal::Stream,
 
-    input_channel_receiver: Arc<Mutex<Box<dyn Stream<Item = VoicePacket<Serverbound>> + Unpin>>>,
+    input_channel_receiver: Arc<tokio::sync::Mutex<Box<dyn Stream<Item = VoicePacket<Serverbound>> + Unpin>>>,
     input_volume_sender: watch::Sender<f32>,
 
     output_volume_sender: watch::Sender<f32>,
@@ -227,7 +227,7 @@ impl Audio {
             _output_stream: output_stream,
             _input_stream: input_stream,
             input_volume_sender,
-            input_channel_receiver: Arc::new(Mutex::new(Box::new(opus_stream))),
+            input_channel_receiver: Arc::new(tokio::sync::Mutex::new(Box::new(opus_stream))),
             client_streams,
             sounds: HashMap::new(),
             output_volume_sender,
@@ -337,7 +337,7 @@ impl Audio {
         }
     }
 
-    pub fn input_receiver(&self) -> Arc<Mutex<Box<dyn Stream<Item = VoicePacket<Serverbound>> + Unpin>>> {
+    pub fn input_receiver(&self) -> Arc<tokio::sync::Mutex<Box<dyn Stream<Item = VoicePacket<Serverbound>> + Unpin>>> {
         Arc::clone(&self.input_channel_receiver)
     }
 

--- a/mumd/src/audio.rs
+++ b/mumd/src/audio.rs
@@ -31,7 +31,7 @@ use std::{
 };
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
-use tokio::sync::watch;
+use tokio::sync::{watch};
 
 const SAMPLE_RATE: u32 = 48000;
 
@@ -132,11 +132,11 @@ impl Audio {
 
         let err_fn = |err| error!("An error occurred on the output audio stream: {}", err);
 
-        let user_volumes = Arc::new(Mutex::new(HashMap::new()));
+        let user_volumes = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let (output_volume_sender, output_volume_receiver) = watch::channel::<f32>(output_volume);
-        let play_sounds = Arc::new(Mutex::new(VecDeque::new()));
+        let play_sounds = Arc::new(std::sync::Mutex::new(VecDeque::new()));
 
-        let client_streams = Arc::new(Mutex::new(HashMap::new()));
+        let client_streams = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let output_stream = match output_supported_sample_format {
             SampleFormat::F32 => output_device.build_output_stream(
                 &output_config,
@@ -292,7 +292,7 @@ impl Audio {
             .collect();
     }
 
-    pub fn decode_packet(&self, stream_type: VoiceStreamType, session_id: u32, payload: VoicePacketPayload) {
+    pub fn decode_packet_payload(&self, stream_type: VoiceStreamType, session_id: u32, payload: VoicePacketPayload) {
         match self.client_streams.lock().unwrap().entry((stream_type, session_id)) {
             Entry::Occupied(mut entry) => {
                 entry

--- a/mumd/src/audio/output.rs
+++ b/mumd/src/audio/output.rs
@@ -1,3 +1,5 @@
+use crate::network::VoiceStreamType;
+
 use cpal::{OutputCallbackInfo, Sample};
 use mumble_protocol::voice::VoicePacketPayload;
 use opus::Channels;
@@ -73,7 +75,7 @@ impl SaturatingAdd for u16 {
 
 pub fn curry_callback<T: Sample + AddAssign + SaturatingAdd + std::fmt::Display>(
     effect_sound: Arc<Mutex<VecDeque<f32>>>,
-    user_bufs: Arc<Mutex<HashMap<u32, ClientStream>>>,
+    user_bufs: Arc<Mutex<HashMap<(VoiceStreamType, u32), ClientStream>>>,
     output_volume_receiver: watch::Receiver<f32>,
     user_volumes: Arc<Mutex<HashMap<u32, (f32, bool)>>>,
 ) -> impl FnMut(&mut [T], &OutputCallbackInfo) + Send + 'static {
@@ -86,7 +88,7 @@ pub fn curry_callback<T: Sample + AddAssign + SaturatingAdd + std::fmt::Display>
 
         let mut effects_sound = effect_sound.lock().unwrap();
         let mut user_bufs = user_bufs.lock().unwrap();
-        for (id, client_stream) in &mut *user_bufs {
+        for ((_, id), client_stream) in &mut *user_bufs {
             let (user_volume, muted) = user_volumes
                 .lock()
                 .unwrap()

--- a/mumd/src/client.rs
+++ b/mumd/src/client.rs
@@ -6,8 +6,8 @@ use futures_util::join;
 use ipc_channel::ipc::IpcSender;
 use mumble_protocol::{Serverbound, control::ControlPacket, crypt::ClientCryptState};
 use mumlib::command::{Command, CommandResponse};
-use std::sync::{Arc, Mutex};
-use tokio::sync::{mpsc, watch};
+use std::sync::Arc;
+use tokio::sync::{mpsc, watch, Mutex};
 
 pub async fn handle(
     command_receiver: mpsc::UnboundedReceiver<(

--- a/mumd/src/command.rs
+++ b/mumd/src/command.rs
@@ -26,11 +26,9 @@ pub async fn handle(
     debug!("Begin listening for commands");
     while let Some((command, response_sender)) = command_receiver.recv().await {
         debug!("Received command {:?}", command);
-        debug!("locking state");
         let mut state = state.lock().await;
         let event = state.handle_command(command, &mut packet_sender, &mut connection_info_sender);
         drop(state);
-        debug!("unlocking state");
         match event {
             ExecutionContext::TcpEvent(event, generator) => {
                 let (tx, rx) = oneshot::channel();

--- a/mumd/src/main.rs
+++ b/mumd/src/main.rs
@@ -14,7 +14,7 @@ use std::fs;
 use tokio::sync::mpsc;
 use tokio::task::spawn_blocking;
 
-#[tokio::main]
+#[tokio::main(worker_threads = 4)]
 async fn main() {
     setup_logger(std::io::stderr(), true);
     notify::init();

--- a/mumd/src/main.rs
+++ b/mumd/src/main.rs
@@ -14,7 +14,7 @@ use std::fs;
 use tokio::sync::mpsc;
 use tokio::task::spawn_blocking;
 
-#[tokio::main(worker_threads = 4)]
+#[tokio::main]
 async fn main() {
     setup_logger(std::io::stderr(), true);
     notify::init();

--- a/mumd/src/network.rs
+++ b/mumd/src/network.rs
@@ -3,6 +3,16 @@ pub mod udp;
 
 use std::net::SocketAddr;
 
+use futures::Future;
+use futures::FutureExt;
+use futures::channel::oneshot;
+use futures::join;
+use futures::pin_mut;
+use futures::select;
+use tokio::sync::watch;
+
+use crate::state::StatePhase;
+
 #[derive(Clone, Debug)]
 pub struct ConnectionInfo {
     socket_addr: SocketAddr,
@@ -24,4 +34,56 @@ impl ConnectionInfo {
 pub enum VoiceStreamType {
     TCP,
     UDP,
+}
+
+async fn run_until<T, F, G, H>(
+    phase_checker: impl Fn(StatePhase) -> bool,
+    mut generator: impl FnMut() -> F,
+    mut handler: impl FnMut(T) -> G,
+    mut shutdown: impl FnMut() -> H,
+    mut phase_watcher: watch::Receiver<StatePhase>,
+) where
+    F: Future<Output = Option<T>>,
+    G: Future<Output = ()>,
+    H: Future<Output = ()>,
+{
+    let (tx, rx) = oneshot::channel();
+    let phase_transition_block = async {
+        loop {
+            phase_watcher.changed().await.unwrap();
+            if phase_checker(*phase_watcher.borrow()) {
+                break;
+            }
+        }
+        tx.send(true).unwrap();
+    };
+
+    let main_block = async {
+        let rx = rx.fuse();
+        pin_mut!(rx);
+        loop {
+            let packet_recv = generator().fuse();
+            pin_mut!(packet_recv);
+            let exitor = select! {
+                data = packet_recv => Some(data),
+                _ = rx => None
+            };
+            match exitor {
+                None => {
+                    break;
+                }
+                Some(None) => {
+                    //warn!("Channel closed before disconnect command"); //TODO make me informative
+                    break;
+                }
+                Some(Some(data)) => {
+                    handler(data).await;
+                }
+            }
+        }
+
+        shutdown().await;
+    };
+
+    join!(main_block, phase_transition_block);
 }

--- a/mumd/src/network.rs
+++ b/mumd/src/network.rs
@@ -1,16 +1,15 @@
 pub mod tcp;
 pub mod udp;
 
-use std::net::SocketAddr;
-
 use futures::Future;
 use futures::FutureExt;
 use futures::channel::oneshot;
 use futures::join;
 use futures::pin_mut;
 use futures::select;
-use tokio::sync::watch;
 use log::*;
+use std::net::SocketAddr;
+use tokio::sync::watch;
 
 use crate::state::StatePhase;
 

--- a/mumd/src/network.rs
+++ b/mumd/src/network.rs
@@ -19,3 +19,9 @@ impl ConnectionInfo {
         }
     }
 }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum VoiceStreamType {
+    TCP,
+    UDP,
+}

--- a/mumd/src/network.rs
+++ b/mumd/src/network.rs
@@ -36,14 +36,12 @@ pub enum VoiceStreamType {
     UDP,
 }
 
-async fn run_until<F, G>(
+async fn run_until<F>(
     phase_checker: impl Fn(StatePhase) -> bool,
     fut: F,
-    mut shutdown: impl FnMut() -> G,
     mut phase_watcher: watch::Receiver<StatePhase>,
 ) where
     F: Future<Output = ()>,
-    G: Future<Output = ()>,
 {
     let (tx, rx) = oneshot::channel();
     let phase_transition_block = async {
@@ -67,8 +65,6 @@ async fn run_until<F, G>(
             _ = fut => (),
             _ = rx => (),
         };
-
-        shutdown().await;
     };
 
     join!(main_block, phase_transition_block);

--- a/mumd/src/network/tcp.rs
+++ b/mumd/src/network/tcp.rs
@@ -184,7 +184,7 @@ async fn send_packets(
 
 async fn send_voice(
     packet_sender: mpsc::UnboundedSender<ControlPacket<Serverbound>>,
-    receiver: Arc<Mutex<Box<(dyn Stream<Item = VoicePacket<Serverbound>> + Unpin)>>>,
+    receiver: Arc<tokio::sync::Mutex<Box<(dyn Stream<Item = VoicePacket<Serverbound>> + Unpin)>>>,
     phase_watcher: watch::Receiver<StatePhase>,
 ) {
     let inner_phase_watcher = phase_watcher.clone();
@@ -196,7 +196,7 @@ async fn send_voice(
                 || async {
                     packet_sender.send(receiver
                                        .lock()
-                                       .unwrap()
+                                       .await
                                        .next()
                                        .await
                                        .unwrap()
@@ -208,6 +208,7 @@ async fn send_voice(
                 || async {},
                 inner_phase_watcher.clone(),
             ).await;
+            debug!("Stopped sending TCP voice");
             Some(Some(()))
         },
         |_| async {},

--- a/mumd/src/network/tcp.rs
+++ b/mumd/src/network/tcp.rs
@@ -1,9 +1,8 @@
 use crate::network::ConnectionInfo;
 use crate::state::{State, StatePhase};
-use futures::Stream;
 use log::*;
 
-use futures::{join, SinkExt, StreamExt};
+use futures::{join, SinkExt, Stream, StreamExt};
 use futures_util::stream::{SplitSink, SplitStream};
 use mumble_protocol::control::{msgs, ClientControlCodec, ControlCodec, ControlPacket};
 use mumble_protocol::crypt::ClientCryptState;
@@ -145,7 +144,7 @@ async fn send_pings(
         async {
             loop {
                 interval.tick().await;
-                trace!("Sending ping");
+                trace!("Sending TCP ping");
                 let msg = msgs::Ping::new();
                 packet_sender.send(msg.into()).unwrap();
             }

--- a/mumd/src/network/tcp.rs
+++ b/mumd/src/network/tcp.rs
@@ -2,17 +2,15 @@ use crate::network::ConnectionInfo;
 use crate::state::{State, StatePhase};
 use log::*;
 
-use futures::{join, SinkExt, Stream, StreamExt};
+use futures::{FutureExt, SinkExt, Stream, StreamExt};
 use futures_util::stream::{SplitSink, SplitStream};
 use mumble_protocol::control::{msgs, ClientControlCodec, ControlCodec, ControlPacket};
 use mumble_protocol::crypt::ClientCryptState;
 use mumble_protocol::voice::VoicePacket;
 use mumble_protocol::{Clientbound, Serverbound};
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::{Into, TryInto};
 use std::net::SocketAddr;
-use std::rc::Rc;
 use std::sync::Arc;
 use tokio::net::TcpStream;
 use tokio::sync::{mpsc, watch, Mutex};
@@ -21,6 +19,7 @@ use tokio_native_tls::{TlsConnector, TlsStream};
 use tokio_util::codec::{Decoder, Framed};
 
 use super::{run_until, VoiceStreamType};
+use futures_util::future::join5;
 
 type TcpSender = SplitSink<
     Framed<TlsStream<TcpStream>, ControlCodec<Serverbound, Clientbound>>,
@@ -76,24 +75,34 @@ pub async fn handle(
 
         info!("Logging in...");
 
-        //TODO force exit all futures on disconnection
-        join!(
-            send_pings(packet_sender.clone(), 10, phase_watcher.clone()),
-            listen(
-                Arc::clone(&state),
-                stream,
-                crypt_state_sender.clone(),
-                Arc::clone(&event_queue),
-                phase_watcher.clone(),
-            ),
-            send_voice(
-                packet_sender.clone(),
-                Arc::clone(&input_receiver),
-                phase_watcher.clone(),
-            ),
-            send_packets(sink, &mut packet_receiver, phase_watcher.clone()),
-            register_events(&mut tcp_event_register_receiver, event_queue, phase_watcher),
-        );
+        run_until(
+            |phase| matches!(phase, StatePhase::Disconnected),
+            join5(
+                send_pings(packet_sender.clone(), 10),
+                listen(
+                    Arc::clone(&state),
+                    stream,
+                    crypt_state_sender.clone(),
+                    Arc::clone(&event_queue),
+                ),
+                send_voice(
+                    packet_sender.clone(),
+                    Arc::clone(&input_receiver),
+                    phase_watcher.clone(),
+                ),
+                send_packets(sink, &mut packet_receiver),
+                register_events(&mut tcp_event_register_receiver, Arc::clone(&event_queue)),
+            ).map(|_| ()),
+            || async {},
+            phase_watcher,
+        ).await;
+
+        if let Some(vec) = event_queue.lock().await.get_mut(&TcpEvent::Disconnected) {
+            let old = std::mem::take(vec);
+            for handler in old {
+                handler(TcpEventData::Disconnected);
+            }
+        }
 
         debug!("Fully disconnected TCP stream, waiting for new connection info");
     }
@@ -135,50 +144,24 @@ async fn authenticate(sink: &mut TcpSender, username: String) {
 async fn send_pings(
     packet_sender: mpsc::UnboundedSender<ControlPacket<Serverbound>>,
     delay_seconds: u64,
-    phase_watcher: watch::Receiver<StatePhase>,
 ) {
     let mut interval = time::interval(Duration::from_secs(delay_seconds));
-
-    run_until(
-        |phase| matches!(phase, StatePhase::Disconnected),
-        async {
-            loop {
-                interval.tick().await;
-                trace!("Sending TCP ping");
-                let msg = msgs::Ping::new();
-                packet_sender.send(msg.into()).unwrap();
-            }
-        },
-        || async {},
-        phase_watcher,
-    )
-    .await;
-
-    debug!("Ping sender process killed");
+        loop {
+            interval.tick().await;
+            trace!("Sending TCP ping");
+            let msg = msgs::Ping::new();
+            packet_sender.send(msg.into()).unwrap();
+        }
 }
 
 async fn send_packets(
-    sink: TcpSender,
+    mut sink: TcpSender,
     packet_receiver: &mut mpsc::UnboundedReceiver<ControlPacket<Serverbound>>,
-    phase_watcher: watch::Receiver<StatePhase>,
 ) {
-    let sink = Rc::new(RefCell::new(sink));
-    run_until(
-        |phase| matches!(phase, StatePhase::Disconnected),
-        async {
-            loop {
-                let packet = packet_receiver.recv().await.unwrap();
-                sink.borrow_mut().send(packet).await.unwrap();
-            }
-        },
-        || async {
-            sink.borrow_mut().close().await.unwrap();
-        },
-        phase_watcher,
-    )
-    .await;
-
-    debug!("TCP packet sender killed");
+    loop {
+        let packet = packet_receiver.recv().await.unwrap();
+        sink.send(packet).await.unwrap();
+    }
 }
 
 async fn send_voice(
@@ -186,41 +169,33 @@ async fn send_voice(
     receiver: Arc<Mutex<Box<(dyn Stream<Item = VoicePacket<Serverbound>> + Unpin)>>>,
     phase_watcher: watch::Receiver<StatePhase>,
 ) {
-    let inner_phase_watcher = phase_watcher.clone();
-    run_until(
-        |phase| matches!(phase, StatePhase::Disconnected),
-        async {
-            loop {
-                let mut inner_phase_watcher_2 = inner_phase_watcher.clone();
-                loop {
-                    inner_phase_watcher_2.changed().await.unwrap();
-                    if matches!(*inner_phase_watcher.borrow(), StatePhase::Connected(VoiceStreamType::TCP)) {
-                        break;
-                    }
-                }
-                run_until(
-                    |phase| !matches!(phase, StatePhase::Connected(VoiceStreamType::TCP)),
-                    async {
-                        loop {
-                            packet_sender.send(
-                                receiver
-                                    .lock()
-                                    .await
-                                    .next()
-                                    .await
-                                    .unwrap()
-                                    .into())
-                                .unwrap();
-                        }
-                    },
-                    || async {},
-                    inner_phase_watcher.clone(),
-                ).await;
+    loop {
+        let mut inner_phase_watcher = phase_watcher.clone();
+        loop {
+            inner_phase_watcher.changed().await.unwrap();
+            if matches!(*inner_phase_watcher.borrow(), StatePhase::Connected(VoiceStreamType::TCP)) {
+                break;
             }
-        },
-        || async {},
-        phase_watcher,
-    ).await;
+        }
+        run_until(
+            |phase| !matches!(phase, StatePhase::Connected(VoiceStreamType::TCP)),
+            async {
+                loop {
+                    packet_sender.send(
+                        receiver
+                            .lock()
+                            .await
+                            .next()
+                            .await
+                            .unwrap()
+                            .into())
+                        .unwrap();
+                }
+            },
+            || async {},
+            inner_phase_watcher.clone(),
+        ).await;
+    }
 }
 
 async fn listen(
@@ -228,158 +203,129 @@ async fn listen(
     mut stream: TcpReceiver,
     crypt_state_sender: mpsc::Sender<ClientCryptState>,
     event_queue: Arc<Mutex<HashMap<TcpEvent, Vec<TcpEventCallback>>>>,
-    phase_watcher: watch::Receiver<StatePhase>,
 ) {
-    let crypt_state = Rc::new(RefCell::new(None));
-    let crypt_state_sender = Rc::new(RefCell::new(Some(crypt_state_sender)));
+    let mut crypt_state = None;
+    let mut crypt_state_sender = Some(crypt_state_sender);
 
-    run_until(
-        |phase| matches!(phase, StatePhase::Disconnected),
-        async {
-            loop {
-                let packet = stream.next().await.unwrap();
-                match packet.unwrap() {
-                    ControlPacket::TextMessage(msg) => {
-                        info!(
-                            "Got message from user with session ID {}: {}",
-                            msg.get_actor(),
-                            msg.get_message()
-                        );
+    loop {
+        let packet = stream.next().await.unwrap();
+        match packet.unwrap() {
+            ControlPacket::TextMessage(msg) => {
+                info!(
+                    "Got message from user with session ID {}: {}",
+                    msg.get_actor(),
+                    msg.get_message()
+                );
+            }
+            ControlPacket::CryptSetup(msg) => {
+                debug!("Crypt setup");
+                // Wait until we're fully connected before initiating UDP voice
+                crypt_state = Some(ClientCryptState::new_from(
+                    msg.get_key()
+                        .try_into()
+                        .expect("Server sent private key with incorrect size"),
+                    msg.get_client_nonce()
+                        .try_into()
+                        .expect("Server sent client_nonce with incorrect size"),
+                    msg.get_server_nonce()
+                        .try_into()
+                        .expect("Server sent server_nonce with incorrect size"),
+                ));
+            }
+            ControlPacket::ServerSync(msg) => {
+                info!("Logged in");
+                if let Some(sender) = crypt_state_sender.take() {
+                    let _ = sender
+                        .send(
+                            crypt_state
+                                .take()
+                                .expect("Server didn't send us any CryptSetup packet!"),
+                        )
+                        .await;
+                }
+                if let Some(vec) = event_queue.lock().await.get_mut(&TcpEvent::Connected) {
+                    let old = std::mem::take(vec);
+                    for handler in old {
+                        handler(TcpEventData::Connected(&msg));
                     }
-                    ControlPacket::CryptSetup(msg) => {
-                        debug!("Crypt setup");
-                        // Wait until we're fully connected before initiating UDP voice
-                        *crypt_state.borrow_mut() = Some(ClientCryptState::new_from(
-                            msg.get_key()
-                                .try_into()
-                                .expect("Server sent private key with incorrect size"),
-                            msg.get_client_nonce()
-                                .try_into()
-                                .expect("Server sent client_nonce with incorrect size"),
-                            msg.get_server_nonce()
-                                .try_into()
-                                .expect("Server sent server_nonce with incorrect size"),
-                        ));
-                    }
-                    ControlPacket::ServerSync(msg) => {
-                        info!("Logged in");
-                        if let Some(sender) = crypt_state_sender.borrow_mut().take() {
-                            let _ = sender
-                                .send(
-                                    crypt_state
-                                        .borrow_mut()
-                                        .take()
-                                        .expect("Server didn't send us any CryptSetup packet!"),
-                                )
-                                .await;
-                        }
-                        if let Some(vec) = event_queue.lock().await.get_mut(&TcpEvent::Connected) {
-                            let old = std::mem::take(vec);
-                            for handler in old {
-                                handler(TcpEventData::Connected(&msg));
-                            }
-                        }
-                        let mut state = state.lock().await;
-                        let server = state.server_mut().unwrap();
-                        server.parse_server_sync(*msg);
-                        match &server.welcome_text {
-                            Some(s) => info!("Welcome: {}", s),
-                            None => info!("No welcome received"),
-                        }
-                        for channel in server.channels().values() {
-                            info!("Found channel {}", channel.name());
-                        }
-                        state.initialized();
-                    }
-                    ControlPacket::Reject(msg) => {
-                        warn!("Login rejected: {:?}", msg);
-                    }
-                    ControlPacket::UserState(msg) => {
-                        state.lock().await.parse_user_state(*msg);
-                    }
-                    ControlPacket::UserRemove(msg) => {
-                        state.lock().await.remove_client(*msg);
-                    }
-                    ControlPacket::ChannelState(msg) => {
-                        debug!("Channel state received");
+                }
+                let mut state = state.lock().await;
+                let server = state.server_mut().unwrap();
+                server.parse_server_sync(*msg);
+                match &server.welcome_text {
+                    Some(s) => info!("Welcome: {}", s),
+                    None => info!("No welcome received"),
+                }
+                for channel in server.channels().values() {
+                    info!("Found channel {}", channel.name());
+                }
+                state.initialized();
+            }
+            ControlPacket::Reject(msg) => {
+                warn!("Login rejected: {:?}", msg);
+            }
+            ControlPacket::UserState(msg) => {
+                state.lock().await.parse_user_state(*msg);
+            }
+            ControlPacket::UserRemove(msg) => {
+                state.lock().await.remove_client(*msg);
+            }
+            ControlPacket::ChannelState(msg) => {
+                debug!("Channel state received");
+                state
+                    .lock()
+                    .await
+                    .server_mut()
+                    .unwrap()
+                    .parse_channel_state(*msg); //TODO parse initial if initial
+            }
+            ControlPacket::ChannelRemove(msg) => {
+                state
+                    .lock()
+                    .await
+                    .server_mut()
+                    .unwrap()
+                    .parse_channel_remove(*msg);
+            }
+            ControlPacket::UDPTunnel(msg) => {
+                match *msg {
+                    VoicePacket::Ping { .. } => {}
+                    VoicePacket::Audio {
+                        session_id,
+                        // seq_num,
+                        payload,
+                        // position_info,
+                        ..
+                    } => {
                         state
                             .lock()
                             .await
-                            .server_mut()
-                            .unwrap()
-                            .parse_channel_state(*msg); //TODO parse initial if initial
-                    }
-                    ControlPacket::ChannelRemove(msg) => {
-                        state
-                            .lock()
-                            .await
-                            .server_mut()
-                            .unwrap()
-                            .parse_channel_remove(*msg);
-                    }
-                    ControlPacket::UDPTunnel(msg) => {
-                        match *msg {
-                            VoicePacket::Ping { .. } => {}
-                            VoicePacket::Audio {
+                            .audio()
+                            .decode_packet_payload(
+                                VoiceStreamType::TCP,
                                 session_id,
-                                // seq_num,
-                                payload,
-                                // position_info,
-                                ..
-                            } => {
-                                state
-                                    .lock()
-                                    .await
-                                    .audio()
-                                    .decode_packet_payload(
-                                        VoiceStreamType::TCP,
-                                        session_id,
-                                        payload);
-                            }
-                        }
-                    }
-                    packet => {
-                        debug!("Received unhandled ControlPacket {:#?}", packet);
+                                payload);
                     }
                 }
             }
-        },
-        || async {
-            if let Some(vec) = event_queue.lock().await.get_mut(&TcpEvent::Disconnected) {
-                let old = std::mem::take(vec);
-                for handler in old {
-                    handler(TcpEventData::Disconnected);
-                }
+            packet => {
+                debug!("Received unhandled ControlPacket {:#?}", packet);
             }
-        },
-        phase_watcher,
-    )
-    .await;
-
-    debug!("Killing TCP listener block");
+        }
+    }
 }
 
 async fn register_events(
     tcp_event_register_receiver: &mut mpsc::UnboundedReceiver<(TcpEvent, TcpEventCallback)>,
     event_data: Arc<Mutex<HashMap<TcpEvent, Vec<TcpEventCallback>>>>,
-    phase_watcher: watch::Receiver<StatePhase>,
 ) {
-    let tcp_event_register_receiver = Rc::new(RefCell::new(tcp_event_register_receiver));
-    run_until(
-        |phase| matches!(phase, StatePhase::Disconnected),
-        async {
-            loop {
-                let (event, handler) = tcp_event_register_receiver.borrow_mut().recv().await.unwrap();
-                event_data
-                    .lock()
-                    .await
-                    .entry(event)
-                    .or_default()
-                    .push(handler);
-            }
-        },
-        || async {},
-        phase_watcher,
-    )
-    .await;
+    loop {
+        let (event, handler) = tcp_event_register_receiver.recv().await.unwrap();
+        event_data
+            .lock()
+            .await
+            .entry(event)
+            .or_default()
+            .push(handler);
+    }
 }

--- a/mumd/src/network/tcp.rs
+++ b/mumd/src/network/tcp.rs
@@ -93,7 +93,6 @@ pub async fn handle(
                 send_packets(sink, &mut packet_receiver),
                 register_events(&mut tcp_event_register_receiver, Arc::clone(&event_queue)),
             ).map(|_| ()),
-            || async {},
             phase_watcher,
         ).await;
 
@@ -192,7 +191,6 @@ async fn send_voice(
                         .unwrap();
                 }
             },
-            || async {},
             inner_phase_watcher.clone(),
         ).await;
     }

--- a/mumd/src/network/udp.rs
+++ b/mumd/src/network/udp.rs
@@ -233,22 +233,18 @@ async fn send_voice(
     let inner_phase_watcher = phase_watcher.clone();
     run_until(
         |phase| matches!(phase, StatePhase::Disconnected),
-        || async {
+        async {
             run_until(
                 |phase| !matches!(phase, StatePhase::Connected(VoiceStreamType::UDP)),
-                || async {
+                async {
                     debug!("Sending UDP audio");
                     sink.lock().unwrap().send((receiver.lock().await.next().await.unwrap(), server_addr)).await.unwrap();
                     debug!("Sent UDP audio");
-                    Some(Some(()))
                 },
-                |_| async {},
                 || async {},
                 inner_phase_watcher.clone(),
             ).await;
-            Some(Some(()))
         },
-        |_| async {},
         || async {},
         phase_watcher,
     ).await;

--- a/mumd/src/network/udp.rs
+++ b/mumd/src/network/udp.rs
@@ -73,7 +73,6 @@ pub async fn handle(
                 ),
                 new_crypt_state(&mut crypt_state_receiver, sink, source),
             ).map(|_| ()),
-            || async {},
             phase_watcher,
         ).await;
 
@@ -217,7 +216,6 @@ async fn send_voice(
                     sink.lock().await.send(sending).await.unwrap();
                 }
             },
-            || async {},
             phase_watcher.clone(),
         ).await;
     }

--- a/mumd/src/network/udp.rs
+++ b/mumd/src/network/udp.rs
@@ -1,13 +1,12 @@
 use crate::network::ConnectionInfo;
 use crate::state::{State, StatePhase};
 
-use bytes::Bytes;
 use futures::{join, pin_mut, select, FutureExt, SinkExt, StreamExt, Stream};
 use futures_util::stream::{SplitSink, SplitStream};
 use log::*;
 use mumble_protocol::crypt::ClientCryptState;
 use mumble_protocol::ping::{PingPacket, PongPacket};
-use mumble_protocol::voice::{VoicePacket, VoicePacketPayload};
+use mumble_protocol::voice::VoicePacket;
 use mumble_protocol::Serverbound;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -16,6 +15,7 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, oneshot, watch};
+use tokio::time::{interval, Duration};
 use tokio_util::udp::UdpFramed;
 
 use super::VoiceStreamType;
@@ -41,12 +41,7 @@ pub async fn handle(
             }
             return;
         };
-        let (mut sink, source) = connect(&mut crypt_state_receiver).await;
-
-        // Note: A normal application would also send periodic Ping packets, and its own audio
-        //       via UDP. We instead trick the server into accepting us by sending it one
-        //       dummy voice packet.
-        send_ping(&mut sink, connection_info.socket_addr).await;
+        let (sink, source) = connect(&mut crypt_state_receiver).await;
 
         let sink = Arc::new(Mutex::new(sink));
         let source = Arc::new(Mutex::new(source));
@@ -54,14 +49,22 @@ pub async fn handle(
         let phase_watcher = state.lock().unwrap().phase_receiver();
         let mut audio_receiver_lock = receiver.lock().unwrap();
         join!(
-            listen(Arc::clone(&state), Arc::clone(&source), phase_watcher.clone()),
+            listen(
+                Arc::clone(&state),
+                Arc::clone(&source),
+                phase_watcher.clone()
+            ),
             send_voice(
                 Arc::clone(&sink),
                 connection_info.socket_addr,
                 phase_watcher,
                 &mut *audio_receiver_lock
             ),
-            new_crypt_state(&mut crypt_state_receiver, sink, source)
+            send_pings(
+                Arc::clone(&sink),
+                connection_info.socket_addr,
+            ),
+            new_crypt_state(&mut crypt_state_receiver, sink, source),
         );
 
         debug!("Fully disconnected UDP stream, waiting for new connection info");
@@ -180,20 +183,23 @@ async fn listen(
     debug!("UDP listener process killed");
 }
 
-async fn send_ping(sink: &mut UdpSender, server_addr: SocketAddr) {
-    sink.send((
-        VoicePacket::Audio {
-            _dst: std::marker::PhantomData,
-            target: 0,
-            session_id: (),
-            seq_num: 0,
-            payload: VoicePacketPayload::Opus(Bytes::from([0u8; 128].as_ref()), true),
-            position_info: None,
-        },
-        server_addr,
-    ))
-    .await
-    .unwrap();
+async fn send_pings(sink: Arc<Mutex<UdpSender>>, server_addr: SocketAddr) {
+    let mut interval = interval(Duration::from_millis(1000));
+
+    loop {
+        match sink
+            .lock()
+            .unwrap()
+            .send((VoicePacket::Ping { timestamp: 0 }, server_addr))
+            .await
+        {
+            Ok(_) => { /* TODO */ },
+            Err(e) => {
+                debug!("Error sending UDP ping: {}", e);
+            }
+        }
+        interval.tick().await;
+    }
 }
 
 async fn send_voice(

--- a/mumd/src/network/udp.rs
+++ b/mumd/src/network/udp.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::net::{Ipv6Addr, SocketAddr};
 use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, oneshot, watch};
@@ -47,22 +48,26 @@ pub async fn handle(
         let source = Arc::new(Mutex::new(source));
 
         let phase_watcher = state.lock().unwrap().phase_receiver();
+        let last_ping_recv = AtomicU64::new(0);
         let mut audio_receiver_lock = receiver.lock().unwrap();
         join!(
             listen(
                 Arc::clone(&state),
                 Arc::clone(&source),
-                phase_watcher.clone()
+                phase_watcher.clone(),
+                &last_ping_recv,
             ),
             send_voice(
                 Arc::clone(&sink),
                 connection_info.socket_addr,
                 phase_watcher,
-                &mut *audio_receiver_lock
+                &mut *audio_receiver_lock,
             ),
             send_pings(
+                Arc::clone(&state),
                 Arc::clone(&sink),
                 connection_info.socket_addr,
+                &last_ping_recv,
             ),
             new_crypt_state(&mut crypt_state_receiver, sink, source),
         );
@@ -113,6 +118,7 @@ async fn listen(
     state: Arc<Mutex<State>>,
     source: Arc<Mutex<UdpReceiver>>,
     mut phase_watcher: watch::Receiver<StatePhase>,
+    last_ping_recv: &AtomicU64,
 ) {
     let (tx, rx) = oneshot::channel();
     let phase_transition_block = async {
@@ -154,10 +160,12 @@ async fn listen(
                         }
                     };
                     match packet {
-                        VoicePacket::Ping { .. } => {
-                            // Note: A normal application would handle these and only use UDP for voice
-                            //       once it has received one.
-                            continue;
+                        VoicePacket::Ping { timestamp } => {
+                            state
+                                .lock()
+                                .unwrap()
+                                .broadcast_phase(StatePhase::Connected(VoiceStreamType::UDP));
+                            last_ping_recv.store(timestamp, Ordering::Relaxed);
                         }
                         VoicePacket::Audio {
                             session_id,
@@ -183,17 +191,32 @@ async fn listen(
     debug!("UDP listener process killed");
 }
 
-async fn send_pings(sink: Arc<Mutex<UdpSender>>, server_addr: SocketAddr) {
+async fn send_pings(
+    state: Arc<Mutex<State>>,
+    sink: Arc<Mutex<UdpSender>>,
+    server_addr: SocketAddr,
+    last_ping_recv: &AtomicU64,
+) {
+    let mut last_send = None;
     let mut interval = interval(Duration::from_millis(1000));
 
     loop {
+        let last_recv = last_ping_recv.load(Ordering::Relaxed);
+        if last_send.is_some() && last_send.unwrap() != last_recv {
+            state
+                .lock()
+                .unwrap()
+                .broadcast_phase(StatePhase::Connected(VoiceStreamType::TCP));
+        }
         match sink
             .lock()
             .unwrap()
             .send((VoicePacket::Ping { timestamp: 0 }, server_addr))
             .await
         {
-            Ok(_) => { /* TODO */ },
+            Ok(_) => {
+                last_send = Some(last_recv + 1);
+            },
             Err(e) => {
                 debug!("Error sending UDP ping: {}", e);
             }

--- a/mumd/src/network/udp.rs
+++ b/mumd/src/network/udp.rs
@@ -18,6 +18,8 @@ use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio_util::udp::UdpFramed;
 
+use super::VoiceStreamType;
+
 pub type PingRequest = (u64, SocketAddr, Box<dyn FnOnce(PongPacket)>);
 
 type UdpSender = SplitSink<UdpFramed<ClientCryptState>, (VoicePacket<Serverbound>, SocketAddr)>;
@@ -165,7 +167,7 @@ async fn listen(
                                 .lock()
                                 .unwrap()
                                 .audio()
-                                .decode_packet(session_id, payload);
+                                .decode_packet(VoiceStreamType::UDP, session_id, payload);
                         }
                     }
                 }

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -578,11 +578,15 @@ impl State {
         }
     }
 
-    pub fn initialized(&self) {
+    pub fn broadcast_phase(&self, phase: StatePhase) {
         self.phase_watcher
             .0
-            .send(StatePhase::Connected(VoiceStreamType::UDP))
+            .send(phase)
             .unwrap();
+    }
+
+    pub fn initialized(&self) {
+        self.broadcast_phase(StatePhase::Connected(VoiceStreamType::TCP));
         self.audio.play_effect(NotificationEvents::ServerConnect);
     }
 


### PR DESCRIPTION
This PR contains a lot of code maintenance as a part of implementing the ability for our client to tunnel audio over TCP. This PR is (spiritually) based off of #47 and as such, it should probably be closed, since it implements mostly the same features. It redoes the implementation of `run_until_disconnection` and makes use of it in more places. It also changes most mutexes to async mutexes to avoid deadlocking/the threadpool being blocked. Finally, it implements TCP voice tunneling, determined by whether or not our UDP pings come through.