### PR TITLE
Mute usability

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,8 +22,10 @@ Added
 * Added tunneling audio through TCP if UDP connection goes down
 * --version now includes the current commit hash.
 
-// Changed
-// ~~~~~~~
+Changed
+~~~~~~~
+
+* Changed how you mute yourself/others. See man pages for details on the new options.
 
 // Removed
 // ~~~~~~~

--- a/documentation/mumctl.1
+++ b/documentation/mumctl.1
@@ -2,12 +2,12 @@
 .\"     Title: mumd
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2020-12-25
+.\"      Date: 2021-03-29
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MUMCTL" "1" "2020-12-25" "\ \&" "\ \&"
+.TH "MUMCTL" "1" "2021-03-29" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -84,9 +84,9 @@ as well).
 If omitted, the port defaults to 64738.
 .RE
 .sp
-mumctl deafen <true|false|toggle>
+mumctl deafen
 .RS 4
-Deafen/undeafen yourself.
+Deafen yourself.
 .RE
 .sp
 mumctl disconnect
@@ -97,6 +97,12 @@ Disconnect from the currently connected server.
 mumctl help
 .RS 4
 Show a help message.
+.RE
+.sp
+mumctl mute [user]
+.RS 4
+Mute yourself or someone else.
+If user is omitted, you mute yourself. Otherwise, the user with the username [user] is muted.
 .RE
 .sp
 mumctl server add [\-\-password <password>] [\-\-port <port>] [\-\-username <username>] [<name>] <host>
@@ -129,9 +135,15 @@ mumctl status
 Show the currently conneced channel and server.
 .RE
 .sp
-mumctl user <name> mute <true|false|toggle>
+mumctl undeafen
 .RS 4
-Mute someone else locally.
+Undeafen yourself.
+.RE
+.sp
+mumctl unmute [user]
+.RS 4
+Unmute yourself or someone else.
+If user is omitted, unmute. Otherwise, the user with the username [user] is unmuted.
 .RE
 .sp
 mumctl volume set <volume>

--- a/documentation/mumctl.1
+++ b/documentation/mumctl.1
@@ -143,7 +143,7 @@ Undeafen yourself.
 mumctl unmute [user]
 .RS 4
 Unmute yourself or someone else.
-If user is omitted, unmute. Otherwise, the user with the username [user] is unmuted.
+If user is omitted, unmute yourself. Otherwise, the user with the username [user] is unmuted.
 .RE
 .sp
 mumctl volume set <volume>

--- a/documentation/mumctl.txt
+++ b/documentation/mumctl.txt
@@ -88,7 +88,7 @@ mumctl undeafen ::
 
 mumctl unmute [user] ::
     Unmute yourself or someone else.
-    If user is omitted, unmute. Otherwise, the user with the username [user] is unmuted.
+    If user is omitted, unmute yourself. Otherwise, the user with the username [user] is unmuted.
 
 mumctl volume set <volume> ::
     Set the outgoing volume level.

--- a/documentation/mumctl.txt
+++ b/documentation/mumctl.txt
@@ -52,14 +52,18 @@ mumctl connect [-p|--port <port>] <host> [username] ::
     as well).
     If omitted, the port defaults to 64738.
 
-mumctl deafen <true|false|toggle> ::
-    Deafen/undeafen yourself.
+mumctl deafen ::
+    Deafen yourself.
 
 mumctl disconnect ::
     Disconnect from the currently connected server.
 
 mumctl help ::
     Show a help message.
+
+mumctl mute [user] ::
+    Mute yourself or someone else.
+    If user is omitted, you mute yourself. Otherwise, the user with the username [user] is muted.
 
 mumctl server add [--password <password>] [--port <port>] [--username <username>] [<name>] <host> ::
     Add a saved server configuration.
@@ -79,8 +83,12 @@ mumctl server rename <old name> <new name> ::
 mumctl status ::
     Show the currently conneced channel and server.
 
-mumctl user <name> mute <true|false|toggle> ::
-    Mute someone else locally.
+mumctl undeafen ::
+    Undeafen yourself.
+
+mumctl unmute [user] ::
+    Unmute yourself or someone else.
+    If user is omitted, unmute. Otherwise, the user with the username [user] is unmuted.
 
 mumctl volume set <volume> ::
     Set the outgoing volume level.

--- a/documentation/mumd.1
+++ b/documentation/mumd.1
@@ -2,12 +2,12 @@
 .\"     Title: mumd
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2020-12-25
+.\"      Date: 2021-01-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MUMD" "1" "2020-12-25" "\ \&" "\ \&"
+.TH "MUMD" "1" "2021-01-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/documentation/mumdrc.5
+++ b/documentation/mumdrc.5
@@ -2,12 +2,12 @@
 .\"     Title: mumdrc
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2020-12-25
+.\"      Date: 2021-01-07
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MUMDRC" "5" "2020-12-25" "\ \&" "\ \&"
+.TH "MUMDRC" "5" "2021-01-07" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0


### PR DESCRIPTION
This PR makes some pretty significant changes to the interface that lets you mute/unmute someone/yourself. Instead of the old complicated interface with lots of options, muting and unmuting yourself is as simple as `mumctl mute` and `mumctl unmute`. To mute a user, you simply have to do `mumctl mute user`. Deafening works similarly.

This also removes the usage of the toggling of being muted/unmuted feature that mumd exposes. We might want to consider deprecating it/removing it entirely in the future.

I'm open to making changes, especially in the man pages.