### PR TITLE
Report tcp login rejects

### DIFF
--- a/mumd/src/main.rs
+++ b/mumd/src/main.rs
@@ -34,7 +34,7 @@ async fn main() {
             bincode::serialize_into((&mut command).writer(), &Command::Ping).unwrap();
             if let Ok(()) = writer.send(command.freeze()).await {
                 if let Some(Ok(buf)) = reader.next().await {
-                    if let Ok(Ok::<Option<CommandResponse>, mumlib::error::Error>(Some(CommandResponse::Pong))) = bincode::deserialize(&buf) {
+                    if let Ok(Ok::<Option<CommandResponse>, mumlib::Error>(Some(CommandResponse::Pong))) = bincode::deserialize(&buf) {
                         error!("Another instance of mumd is already running");
                         return;
                     }

--- a/mumd/src/network/tcp.rs
+++ b/mumd/src/network/tcp.rs
@@ -314,12 +314,13 @@ async fn listen(
                 state.initialized();
             }
             ControlPacket::Reject(msg) => {
+                debug!("Login rejected: {:?}", msg);
                 match msg.get_field_type() {
                     msgs::Reject_RejectType::WrongServerPW => {
                         event_queue.send(TcpEventData::Connected(Err(Error::InvalidServerPassword))).await;
                     }
-                    _ => {
-                        warn!("Login rejected: {:?}", msg);
+                    ty => {
+                        warn!("Unhandled reject type: {:?}", ty);
                     }
                 }
             }

--- a/mumd/src/network/tcp.rs
+++ b/mumd/src/network/tcp.rs
@@ -190,12 +190,12 @@ async fn send_pings(
     delay_seconds: u64,
 ) {
     let mut interval = time::interval(Duration::from_secs(delay_seconds));
-        loop {
-            interval.tick().await;
-            trace!("Sending TCP ping");
-            let msg = msgs::Ping::new();
-            packet_sender.send(msg.into()).unwrap();
-        }
+    loop {
+        interval.tick().await;
+        trace!("Sending TCP ping");
+        let msg = msgs::Ping::new();
+        packet_sender.send(msg.into()).unwrap();
+    }
 }
 
 async fn send_packets(

--- a/mumd/src/network/tcp.rs
+++ b/mumd/src/network/tcp.rs
@@ -38,7 +38,7 @@ pub enum TcpEvent {
 
 #[derive(Clone)]
 pub enum TcpEventData<'a> {
-    Connected(&'a msgs::ServerSync),
+    Connected(Result<&'a msgs::ServerSync, mumlib::error::Error>),
     _Disconnected,
 }
 
@@ -286,7 +286,7 @@ async fn listen(
                         )
                         .await;
                 }
-                event_queue.send(TcpEventData::Connected(&msg)).await;
+                event_queue.send(TcpEventData::Connected(Ok(&msg))).await;
                 let mut state = state.lock().await;
                 let server = state.server_mut().unwrap();
                 server.parse_server_sync(*msg);

--- a/mumd/src/network/tcp.rs
+++ b/mumd/src/network/tcp.rs
@@ -8,7 +8,6 @@ use mumble_protocol::control::{msgs, ClientControlCodec, ControlCodec, ControlPa
 use mumble_protocol::crypt::ClientCryptState;
 use mumble_protocol::voice::VoicePacket;
 use mumble_protocol::{Clientbound, Serverbound};
-use mumlib::error::Error;
 use std::collections::HashMap;
 use std::convert::{Into, TryInto};
 use std::net::SocketAddr;
@@ -39,7 +38,7 @@ pub enum TcpEvent {
 
 #[derive(Clone)]
 pub enum TcpEventData<'a> {
-    Connected(Result<&'a msgs::ServerSync, Error>),
+    Connected(Result<&'a msgs::ServerSync, mumlib::Error>),
     _Disconnected,
 }
 
@@ -317,7 +316,7 @@ async fn listen(
                 debug!("Login rejected: {:?}", msg);
                 match msg.get_field_type() {
                     msgs::Reject_RejectType::WrongServerPW => {
-                        event_queue.send(TcpEventData::Connected(Err(Error::InvalidServerPassword))).await;
+                        event_queue.send(TcpEventData::Connected(Err(mumlib::Error::InvalidServerPassword))).await;
                     }
                     ty => {
                         warn!("Unhandled reject type: {:?}", ty);

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -88,7 +88,7 @@ impl State {
         match command {
             Command::ChannelJoin { channel_identifier } => {
                 if !matches!(*self.phase_receiver().borrow(), StatePhase::Connected(_)) {
-                    return now!(Err(Error::DisconnectedError));
+                    return now!(Err(Error::Disconnected));
                 }
 
                 let channels = self.server().unwrap().channels();
@@ -138,7 +138,7 @@ impl State {
             }
             Command::ChannelList => {
                 if !matches!(*self.phase_receiver().borrow(), StatePhase::Connected(_)) {
-                    return now!(Err(Error::DisconnectedError));
+                    return now!(Err(Error::Disconnected));
                 }
                 let list = channel::into_channel(
                     self.server.as_ref().unwrap().channels(),
@@ -152,7 +152,7 @@ impl State {
             }
             Command::DeafenSelf(toggle) => {
                 if !matches!(*self.phase_receiver().borrow(), StatePhase::Connected(_)) {
-                    return now!(Err(Error::DisconnectedError));
+                    return now!(Err(Error::Disconnected));
                 }
 
                 let server = self.server().unwrap();
@@ -210,7 +210,7 @@ impl State {
             }
             Command::MuteOther(string, toggle) => {
                 if !matches!(*self.phase_receiver().borrow(), StatePhase::Connected(_)) {
-                    return now!(Err(Error::DisconnectedError));
+                    return now!(Err(Error::Disconnected));
                 }
 
                 let id = self
@@ -222,7 +222,7 @@ impl State {
 
                 let (id, user) = match id {
                     Some(id) => (*id.0, id.1),
-                    None => return now!(Err(Error::InvalidUsernameError(string))),
+                    None => return now!(Err(Error::InvalidUsername(string))),
                 };
 
                 let action = match toggle {
@@ -245,7 +245,7 @@ impl State {
             }
             Command::MuteSelf(toggle) => {
                 if !matches!(*self.phase_receiver().borrow(), StatePhase::Connected(_)) {
-                    return now!(Err(Error::DisconnectedError));
+                    return now!(Err(Error::Disconnected));
                 }
 
                 let server = self.server().unwrap();
@@ -313,7 +313,7 @@ impl State {
                 accept_invalid_cert,
             } => {
                 if !matches!(*self.phase_receiver().borrow(), StatePhase::Disconnected) {
-                    return now!(Err(Error::AlreadyConnectedError));
+                    return now!(Err(Error::AlreadyConnected));
                 }
                 let mut server = Server::new();
                 *server.username_mut() = Some(username);
@@ -332,7 +332,7 @@ impl State {
                     Ok(Some(v)) => v,
                     _ => {
                         warn!("Error parsing server addr");
-                        return now!(Err(Error::InvalidServerAddrError(host, port)));
+                        return now!(Err(Error::InvalidServerAddr(host, port)));
                     }
                 };
                 connection_info_sender
@@ -361,7 +361,7 @@ impl State {
             }
             Command::ServerDisconnect => {
                 if !matches!(*self.phase_receiver().borrow(), StatePhase::Connected(_)) {
-                    return now!(Err(Error::DisconnectedError));
+                    return now!(Err(Error::Disconnected));
                 }
 
                 self.server = None;
@@ -381,7 +381,7 @@ impl State {
                         .map(|mut e| e.next())
                     {
                         Ok(Some(v)) => Ok(v),
-                        _ => Err(mumlib::error::Error::InvalidServerAddrError(host, port)),
+                        _ => Err(mumlib::error::Error::InvalidServerAddr(host, port)),
                     }
                 }),
                 Box::new(move |pong| {
@@ -395,7 +395,7 @@ impl State {
             ),
             Command::Status => {
                 if !matches!(*self.phase_receiver().borrow(), StatePhase::Connected(_)) {
-                    return now!(Err(Error::DisconnectedError));
+                    return now!(Err(Error::Disconnected));
                 }
                 let state = self.server.as_ref().unwrap().into();
                 now!(Ok(Some(CommandResponse::Status {
@@ -404,7 +404,7 @@ impl State {
             }
             Command::UserVolumeSet(string, volume) => {
                 if !matches!(*self.phase_receiver().borrow(), StatePhase::Connected(_)) {
-                    return now!(Err(Error::DisconnectedError));
+                    return now!(Err(Error::Disconnected));
                 }
                 let user_id = match self
                     .server()
@@ -414,7 +414,7 @@ impl State {
                     .find(|e| e.1.name() == string)
                     .map(|e| *e.0)
                 {
-                    None => return now!(Err(Error::InvalidUsernameError(string))),
+                    None => return now!(Err(Error::InvalidUsername(string))),
                     Some(v) => v,
                 };
 

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -15,7 +15,8 @@ use mumble_protocol::ping::PongPacket;
 use mumble_protocol::voice::Serverbound;
 use mumlib::command::{Command, CommandResponse};
 use mumlib::config::Config;
-use mumlib::error::{ChannelIdentifierError, Error};
+use mumlib::error::ChannelIdentifierError;
+use mumlib::Error;
 use crate::state::user::UserDiff;
 use std::net::{SocketAddr, ToSocketAddrs};
 use tokio::sync::{mpsc, watch};
@@ -381,7 +382,7 @@ impl State {
                         .map(|mut e| e.next())
                     {
                         Ok(Some(v)) => Ok(v),
-                        _ => Err(mumlib::error::Error::InvalidServerAddr(host, port)),
+                        _ => Err(Error::InvalidServerAddr(host, port)),
                     }
                 }),
                 Box::new(move |pong| {

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -342,16 +342,18 @@ impl State {
                         accept_invalid_cert,
                     )))
                     .unwrap();
-                at!(TcpEvent::Connected, |e| {
+                at!(TcpEvent::Connected, |res| {
                     //runs the closure when the client is connected
-                    if let TcpEventData::Connected(msg) = e {
-                        Ok(Some(CommandResponse::ServerConnect {
-                            welcome_message: if msg.has_welcome_text() {
-                                Some(msg.get_welcome_text().to_string())
-                            } else {
-                                None
-                            },
-                        }))
+                    if let TcpEventData::Connected(res) = res {
+                        res.map(|msg| {
+                            Some(CommandResponse::ServerConnect {
+                                welcome_message: if msg.has_welcome_text() {
+                                    Some(msg.get_welcome_text().to_string())
+                                } else {
+                                    None
+                                },
+                            })
+                        })
                     } else {
                         unreachable!("callback should be provided with a TcpEventData::Connected");
                     }

--- a/mumlib/src/error.rs
+++ b/mumlib/src/error.rs
@@ -5,24 +5,24 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Error {
-    DisconnectedError,
-    AlreadyConnectedError,
+    Disconnected,
+    AlreadyConnected,
     ChannelIdentifierError(String, ChannelIdentifierError),
-    InvalidServerAddrError(String, u16),
-    InvalidUsernameError(String),
+    InvalidServerAddr(String, u16),
+    InvalidUsername(String),
     InvalidServerPassword,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::DisconnectedError => write!(f, "Not connected to a server"),
-            Error::AlreadyConnectedError => write!(f, "Already connected to a server"),
+            Error::Disconnected=> write!(f, "Not connected to a server"),
+            Error::AlreadyConnected=> write!(f, "Already connected to a server"),
             Error::ChannelIdentifierError(id, kind) => write!(f, "{}: {}", kind, id),
-            Error::InvalidServerAddrError(addr, port) => {
+            Error::InvalidServerAddr(addr, port) => {
                 write!(f, "Invalid server address: {}: {}", addr, port)
             }
-            Error::InvalidUsernameError(username) => write!(f, "Invalid username: {}", username),
+            Error::InvalidUsername(username) => write!(f, "Invalid username: {}", username),
             Error::InvalidServerPassword => write!(f, "Invalid server password")
         }
     }

--- a/mumlib/src/error.rs
+++ b/mumlib/src/error.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Error {
     DisconnectedError,
     AlreadyConnectedError,
@@ -26,7 +26,7 @@ impl fmt::Display for Error {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum ChannelIdentifierError {
     Invalid,
     Ambiguous,

--- a/mumlib/src/error.rs
+++ b/mumlib/src/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
     ChannelIdentifierError(String, ChannelIdentifierError),
     InvalidServerAddrError(String, u16),
     InvalidUsernameError(String),
+    InvalidServerPassword,
 }
 
 impl fmt::Display for Error {
@@ -22,6 +23,7 @@ impl fmt::Display for Error {
                 write!(f, "Invalid server address: {}: {}", addr, port)
             }
             Error::InvalidUsernameError(username) => write!(f, "Invalid username: {}", username),
+            Error::InvalidServerPassword => write!(f, "Invalid server password")
         }
     }
 }

--- a/mumlib/src/lib.rs
+++ b/mumlib/src/lib.rs
@@ -3,6 +3,8 @@ pub mod config;
 pub mod error;
 pub mod state;
 
+pub use error::Error;
+
 use colored::*;
 use log::*;
 


### PR DESCRIPTION
Refactor the TCP event handler so reporting an event isn't as daunting. Report errors from the TCP stream and pass them to mumctl.

I took the opportunity to make the TCP stream handling a bit more robust as well. I also removed the error-suffix on most `mumlib::error::Error`s since they always show up as `Error::XError`. Finally, we now export `Error` directly in mumlib.