### PR TITLE
remove cfg_exists, pass paths explicitly

### DIFF
--- a/mumctl/src/main.rs
+++ b/mumctl/src/main.rs
@@ -207,7 +207,7 @@ fn main() {
     }
 }
 fn match_opt() -> Result<(), Error> {
-    let mut config = config::read_default_cfg()?;
+    let mut config = config::read_cfg(&config::default_cfg_path())?;
 
     let opt = Mum::from_args();
     match opt.command {
@@ -347,18 +347,19 @@ fn match_opt() -> Result<(), Error> {
         }
     }
 
-    if !config::cfg_exists() {
+    let config_path = config::default_cfg_path();
+    if !config_path.exists() {
         println!(
             "Config file not found. Create one in {}? [Y/n]",
-            config::default_cfg_path().display(),
+            config_path.display(),
         );
         let stdin = std::io::stdin();
         let response = stdin.lock().lines().next();
         if let Some(Ok(true)) = response.map(|e| e.map(|e| &e == "Y")) {
-            config.write_default_cfg(true)?;
+            config.write(&config_path, true)?;
         }
     } else {
-        config.write_default_cfg(false)?;
+        config.write(&config_path, false)?;
     }
     Ok(())
 }

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -64,7 +64,7 @@ pub struct State {
 
 impl State {
     pub fn new() -> Result<Self, StateError> {
-        let config = mumlib::config::read_default_cfg()?;
+        let config = mumlib::config::read_cfg(&mumlib::config::default_cfg_path())?;
         let phase_watcher = watch::channel(StatePhase::Disconnected);
         let audio = Audio::new(
             config.audio.input_volume.unwrap_or(1.0),
@@ -574,7 +574,7 @@ impl State {
     }
 
     pub fn reload_config(&mut self) {
-        match mumlib::config::read_default_cfg() {
+        match mumlib::config::read_cfg(&mumlib::config::default_cfg_path()) {
             Ok(config) => {
                 self.config = config;
             }


### PR DESCRIPTION
Removes some complexity and makes it easier to (in the future) pass custom config paths. For example, maybe we'd want a way to do

```
$ mumctl -C custom_config.toml server add  # ...
```