### PR TITLE
Text message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ Added
  * Added tunneling audio through TCP if UDP connection goes down.
  * --version now includes the current commit hash.
  * Server passwords. Thanks @rbran!
+ * Added support for sending and receiving text messages
 
 Changed
 ~~~~~~~

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "colored",
  "log",
  "mumlib",
+ "serde",
  "structopt",
 ]
 

--- a/documentation/mumctl.1
+++ b/documentation/mumctl.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: mumd
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-04-03
+.\" Generator: Asciidoctor 2.0.15
+.\"      Date: 2021-06-06
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MUMCTL" "1" "2021-04-03" "\ \&" "\ \&"
+.TH "MUMCTL" "1" "2021-06-06" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -157,6 +157,19 @@ mumctl volume <user> set <volume>
 Set the volume of another user\(cqs incoming audio.
 1.0 is the default.
 .RE
+.sp
+mumctl messages [\-f|\-\-follow]
+Prints all received messages since mumd was started, or since this command last was issued,
+whichever happens first.
+If the follow flag is set, mumctl will instead wait for new messages to come in and print
+them as they come in. To exit this loop, issue a Ctrl\-C.
+.sp
+mumctl message user <message> <users>
+Sends a message to all users specified in the list of users.
+.sp
+mumctl message channel [\-r|\-\-recursive] <message> <channels>
+Sends a message to all channels specified in the list of channels.
+If the recursive flag is set, the message is also sent to all subchannels in a recursive manner.
 .SH "AUTHORS"
 .sp
 Gustav Sörnäs and Eskil Queseth.

--- a/documentation/mumctl.txt
+++ b/documentation/mumctl.txt
@@ -98,6 +98,17 @@ mumctl volume <user> set <volume> ::
     Set the volume of another user's incoming audio.
     1.0 is the default.
 
+mumctl messages
+    Prints all received messages since mumd was started, or since this command last was issued,
+    whichever happens first.
+
+mumctl message user <message> <users>
+    Sends a message to all users specified in the list of users.
+
+mumctl message channel [-r|--recursive] <message> <channels>
+    Sends a message to all channels specified in the list of channels.
+    If the recursive flag is set, the message is also sent to all subchannels in a recursive manner.
+
 Authors
 -------
 

--- a/documentation/mumctl.txt
+++ b/documentation/mumctl.txt
@@ -98,9 +98,11 @@ mumctl volume <user> set <volume> ::
     Set the volume of another user's incoming audio.
     1.0 is the default.
 
-mumctl messages
+mumctl messages [-i|--interactive]
     Prints all received messages since mumd was started, or since this command last was issued,
     whichever happens first.
+    If the interactive flag is set, mumctl will instead wait for new messages to come in and print
+    them as they come in. To exit this loop, issue a Ctrl-C.
 
 mumctl message user <message> <users>
     Sends a message to all users specified in the list of users.

--- a/documentation/mumctl.txt
+++ b/documentation/mumctl.txt
@@ -98,10 +98,10 @@ mumctl volume <user> set <volume> ::
     Set the volume of another user's incoming audio.
     1.0 is the default.
 
-mumctl messages [-i|--interactive]
+mumctl messages [-f|--follow]
     Prints all received messages since mumd was started, or since this command last was issued,
     whichever happens first.
-    If the interactive flag is set, mumctl will instead wait for new messages to come in and print
+    If the follow flag is set, mumctl will instead wait for new messages to come in and print
     them as they come in. To exit this loop, issue a Ctrl-C.
 
 mumctl message user <message> <users>

--- a/documentation/mumd.1
+++ b/documentation/mumd.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: mumd
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-04-03
+.\" Generator: Asciidoctor 2.0.15
+.\"      Date: 2021-04-10
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MUMD" "1" "2021-04-03" "\ \&" "\ \&"
+.TH "MUMD" "1" "2021-04-10" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/documentation/mumdrc.5
+++ b/documentation/mumdrc.5
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: mumdrc
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-04-03
+.\" Generator: Asciidoctor 2.0.15
+.\"      Date: 2021-04-10
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MUMDRC" "5" "2021-04-03" "\ \&" "\ \&"
+.TH "MUMDRC" "5" "2021-04-10" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/mumctl/Cargo.toml
+++ b/mumctl/Cargo.toml
@@ -18,5 +18,6 @@ bincode = "1"
 colored = "2"
 log = "0.4"
 structopt = "0.3"
+serde = "1"
 
 #cursive = "0.15"

--- a/mumctl/src/main.rs
+++ b/mumctl/src/main.rs
@@ -88,6 +88,8 @@ enum Command {
     Deafen,
     /// Undeafen yourself
     Undeafen,
+    /// Get messages
+    Messages,
 }
 
 #[derive(Debug, StructOpt)]
@@ -348,6 +350,16 @@ fn match_opt() -> Result<(), Error> {
         }
         Command::Undeafen => {
             send_command(MumCommand::DeafenSelf(Some(false)))??;
+        }
+        Command::Messages => {
+            match send_command(MumCommand::PastMessages)?? {
+                Some(CommandResponse::PastMessages { messages }) => {
+                    for (msg, sender) in messages {
+                        println!("{}: {}", sender, msg);
+                    }
+                }
+                _ => unreachable!("Response should only be a PastMessages"),
+            }
         }
     }
 

--- a/mumctl/src/main.rs
+++ b/mumctl/src/main.rs
@@ -373,7 +373,7 @@ fn match_opt() -> Result<(), Error> {
             send_command(MumCommand::DeafenSelf(Some(false)))??;
         }
         Command::Messages => {
-            match send_command(MumCommand::PastMessages)?? {
+            match send_command(MumCommand::PastMessages { block: false })?? {
                 Some(CommandResponse::PastMessages { messages }) => {
                     for (msg, sender) in messages {
                         println!("{}: {}", sender, msg);

--- a/mumctl/src/main.rs
+++ b/mumctl/src/main.rs
@@ -645,7 +645,7 @@ fn parse_state(server_state: &mumlib::state::Server) {
     }
 }
 
-/// Tries to find a running mumd instance and tries to receive one response from it.
+/// Tries to find a running mumd instance and receive one response from it.
 fn send_command(
     command: MumCommand,
 ) -> Result<mumlib::error::Result<Option<CommandResponse>>, CliError> {
@@ -667,7 +667,7 @@ fn send_command(
     bincode::deserialize_from(&mut connection).map_err(|_| CliError::ConnectionError)
 }
 
-/// Tries to find a running mumd instance and sends a single command to it. Returns an iterator which
+/// Tries to find a running mumd instance and send a single command to it. Returns an iterator which
 /// yields all responses that mumd sends for that particular command.
 fn send_command_multi(
     command: MumCommand,

--- a/mumctl/src/main.rs
+++ b/mumctl/src/main.rs
@@ -92,8 +92,8 @@ enum Command {
     Undeafen,
     /// Get messages sent to the server you're currently connected to
     Messages {
-        #[structopt(short = "i", long = "interactive")]
-        interactive: bool,
+        #[structopt(short = "f", long = "follow")]
+        follow: bool,
     },
     /// Send a message to a channel or a user
     Message(Target),
@@ -378,9 +378,9 @@ fn match_opt() -> Result<(), Error> {
             send_command(MumCommand::DeafenSelf(Some(false)))??;
         }
         Command::Messages {
-            interactive
+            follow
         } => {
-            for response in send_command_multi(MumCommand::PastMessages { block: interactive })? {
+            for response in send_command_multi(MumCommand::PastMessages { block: follow })? {
                 match response {
                     Ok(Some(CommandResponse::PastMessage { message })) => println!("{}: {}", message.1, message.0),
                     Ok(_) => unreachable!("Response should only be a Some(PastMessages)"),

--- a/mumctl/src/main.rs
+++ b/mumctl/src/main.rs
@@ -645,6 +645,7 @@ fn parse_state(server_state: &mumlib::state::Server) {
     }
 }
 
+/// Tries to find a running mumd instance and tries to receive one response from it.
 fn send_command(
     command: MumCommand,
 ) -> Result<mumlib::error::Result<Option<CommandResponse>>, CliError> {
@@ -666,6 +667,8 @@ fn send_command(
     bincode::deserialize_from(&mut connection).map_err(|_| CliError::ConnectionError)
 }
 
+/// Tries to find a running mumd instance and sends a single command to it. Returns an iterator which
+/// yields all responses that mumd sends for that particular command.
 fn send_command_multi(
     command: MumCommand,
 ) -> Result<impl Iterator<Item = mumlib::error::Result<Option<CommandResponse>>>, CliError> {
@@ -687,12 +690,14 @@ fn send_command_multi(
     Ok(BincodeIter::new(connection))
 }
 
+/// A struct to represent an iterator that deserializes bincode-encoded data from a `Reader`.
 struct BincodeIter<R, I> {
     reader: R,
     phantom: PhantomData<*const I>,
 }
 
 impl<R, I> BincodeIter<R, I> {
+    /// Creates a new `BincodeIter` from a reader.
     fn new(reader: R) -> Self {
         Self {
             reader,

--- a/mumd/src/client.rs
+++ b/mumd/src/client.rs
@@ -1,4 +1,4 @@
-use crate::command;
+use crate::{command, network::tcp::TcpEventQueue};
 use crate::error::ClientError;
 use crate::network::{tcp, udp, ConnectionInfo};
 use crate::state::State;
@@ -24,8 +24,7 @@ pub async fn handle(
         mpsc::unbounded_channel::<ControlPacket<Serverbound>>();
     let (ping_request_sender, ping_request_receiver) =
         mpsc::unbounded_channel();
-    let (response_sender, response_receiver) =
-        mpsc::unbounded_channel();
+    let event_queue = TcpEventQueue::new();
 
     let state = Arc::new(RwLock::new(state));
 
@@ -36,7 +35,7 @@ pub async fn handle(
             crypt_state_sender,
             packet_sender.clone(),
             packet_receiver,
-            response_receiver,
+            event_queue.clone(),
         ).fuse() => r.map_err(|e| ClientError::TcpError(e)),
         _ = udp::handle(
             Arc::clone(&state),
@@ -46,7 +45,7 @@ pub async fn handle(
         _ = command::handle(
             state,
             command_receiver,
-            response_sender,
+            event_queue,
             ping_request_sender,
             packet_sender,
             connection_info_sender,

--- a/mumd/src/client.rs
+++ b/mumd/src/client.rs
@@ -7,13 +7,13 @@ use futures_util::{select, FutureExt};
 use mumble_protocol::{Serverbound, control::ControlPacket, crypt::ClientCryptState};
 use mumlib::command::{Command, CommandResponse};
 use std::sync::{Arc, RwLock};
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::sync::{mpsc, watch};
 
 pub async fn handle(
     state: State,
     command_receiver: mpsc::UnboundedReceiver<(
         Command,
-        oneshot::Sender<mumlib::error::Result<Option<CommandResponse>>>,
+        mpsc::UnboundedSender<mumlib::error::Result<Option<CommandResponse>>>,
     )>,
 ) -> Result<(), ClientError> {
     let (connection_info_sender, connection_info_receiver) =

--- a/mumd/src/command.rs
+++ b/mumd/src/command.rs
@@ -29,7 +29,9 @@ pub async fn handle(
                     event, 
                     Box::new(move |e| {
                         let response = generator(e);
-                        response_sender.send(response).unwrap();
+                        for response in response {
+                            response_sender.send(response).unwrap();
+                        }
                     }),
                 );
             }
@@ -42,7 +44,10 @@ pub async fn handle(
                 )
             }
             ExecutionContext::Now(generator) => {
-                response_sender.send(generator()).unwrap();
+                for response in generator() {
+                    response_sender.send(response).unwrap(); 
+                }
+                drop(response_sender);
             }
             ExecutionContext::Ping(generator, converter) => {
                 let ret = generator();

--- a/mumd/src/command.rs
+++ b/mumd/src/command.rs
@@ -22,9 +22,7 @@ pub async fn handle(
     let ping_count = AtomicU64::new(0);
     while let Some((command, mut response_sender)) = command_receiver.recv().await {
         debug!("Received command {:?}", command);
-        let mut state = state.write().unwrap();
-        let event = state.handle_command(command, &mut packet_sender, &mut connection_info_sender);
-        drop(state);
+        let event = crate::state::handle_command(Arc::clone(&state), command, &mut packet_sender, &mut connection_info_sender);
         match event {
             ExecutionContext::TcpEventCallback(event, generator) => {
                 tcp_event_queue.register_callback(

--- a/mumd/src/command.rs
+++ b/mumd/src/command.rs
@@ -27,18 +27,13 @@ pub async fn handle(
         drop(state);
         match event {
             ExecutionContext::TcpEvent(event, generator) => {
-                let (tx, rx) = oneshot::channel();
-                //TODO handle this error
                 tcp_event_queue.register_callback(
                     event, 
                     Box::new(move |e| {
                         let response = generator(e);
                         response_sender.send(response).unwrap();
-                        tx.send(()).unwrap();
                     }),
                 );
-
-                rx.await.unwrap();
             }
             ExecutionContext::Now(generator) => {
                 response_sender.send(generator()).unwrap();

--- a/mumd/src/main.rs
+++ b/mumd/src/main.rs
@@ -115,6 +115,7 @@ async fn receive_commands(
 
                         if let Err(e) = writer.send(serialized.freeze()).await {
                             error!("Error sending response: {:?}", e);
+                            break;
                         }
                     }
                 }

--- a/mumd/src/network/tcp.rs
+++ b/mumd/src/network/tcp.rs
@@ -269,12 +269,9 @@ async fn listen(
             }
         };
         match packet {
-            ControlPacket::TextMessage(msg) => {
-                info!(
-                    "Got message from user with session ID {}: {}",
-                    msg.get_actor(),
-                    msg.get_message()
-                );
+            ControlPacket::TextMessage(mut msg) => {
+                let mut state = state.write().unwrap();
+                state.register_message((msg.take_message(), msg.get_actor()));
             }
             ControlPacket::CryptSetup(msg) => {
                 debug!("Crypt setup");

--- a/mumd/src/network/tcp.rs
+++ b/mumd/src/network/tcp.rs
@@ -299,6 +299,8 @@ async fn listen(
                     notifications::send(format!("{}: {}", user, msg.get_message())); //TODO: probably want a config flag for this
                 }
                 state.register_message((msg.get_message().to_owned(), msg.get_actor()));
+                drop(state);
+                event_queue.resolve(TcpEventData::TextMessage(&*msg));
             }
             ControlPacket::CryptSetup(msg) => {
                 debug!("Crypt setup");

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -23,7 +23,7 @@ use tokio::sync::{mpsc, watch};
 
 macro_rules! at {
     ($event:expr, $generator:expr) => {
-        ExecutionContext::TcpEvent($event, Box::new($generator))
+        ExecutionContext::TcpEventCallback($event, Box::new($generator))
     };
 }
 
@@ -35,9 +35,13 @@ macro_rules! now {
 
 //TODO give me a better name
 pub enum ExecutionContext {
-    TcpEvent(
+    TcpEventCallback(
         TcpEvent,
         Box<dyn FnOnce(TcpEventData) -> mumlib::error::Result<Option<CommandResponse>>>,
+    ),
+    TcpEventSubscriber(
+        TcpEvent,
+        Box<dyn FnMut(TcpEventData, &mut mpsc::UnboundedSender<mumlib::error::Result<Option<CommandResponse>>>) -> bool>,
     ),
     Now(Box<dyn FnOnce() -> mumlib::error::Result<Option<CommandResponse>>>),
     Ping(

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -393,7 +393,7 @@ impl State {
                 self.audio_output.set_user_volume(user_id, volume);
                 now!(Ok(None))
             }
-            Command::PastMessages => {
+            Command::PastMessages { block } => {
                 let server = match self.server.as_ref() {
                     Some(s) => s,
                     None => return now!(Err(Error::Disconnected)),

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -612,16 +612,6 @@ pub fn handle_command(
         }
         Command::PastMessages { block } => {
             if block {
-                let messages = std::mem::take(&mut state.message_buffer);
-                let server = match state.server.as_ref() {
-                    Some(s) => s,
-                    None => return now!(Err(Error::Disconnected)),
-                };
-                let messages = messages.into_iter()
-                    .map(|(msg, user)| (msg, server.users().get(&user).unwrap().name().to_string())).collect();
-                
-                now!(Ok(Some(CommandResponse::PastMessages { messages })))
-            } else {
                 let ref_state = Arc::clone(&og_state);
                 ExecutionContext::TcpEventSubscriber(
                     TcpEvent::TextMessage,
@@ -637,6 +627,16 @@ pub fn handle_command(
                         }
                     }),
                 )
+            } else {
+                let messages = std::mem::take(&mut state.message_buffer);
+                let server = match state.server.as_ref() {
+                    Some(s) => s,
+                    None => return now!(Err(Error::Disconnected)),
+                };
+                let messages = messages.into_iter()
+                    .map(|(msg, user)| (msg, server.users().get(&user).unwrap().name().to_string())).collect();
+                
+                now!(Ok(Some(CommandResponse::PastMessages { messages })))
             }
         }
         Command::SendMessage { message, targets } => {

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -300,12 +300,15 @@ impl State {
             .1
             .channel()
     }
-    fn get_user_name(&self, user: u32) -> String {
+
+    /// Gets the username of a user with id `user` connected to the same server that we are connected to.
+    /// If we are connected to the server but the user with the id doesn't exist, the string "Unknown user {id}"
+    /// is returned instead. If we aren't connected to a server, None is returned instead.
+    fn get_user_name(&self, user: u32) -> Option<String> {
         self.server()
-            .unwrap()
-            .users()
-            .get(&user).map(|e| e.name().to_string())
-            .unwrap_or(format!("Unknown user {}", user))
+            .map(|e| e.users()
+                .get(&user).map(|e| e.name().to_string())
+                .unwrap_or(format!("Unknown user {}", user)))
     }
 }
 

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -619,7 +619,13 @@ pub fn handle_command(
                         if let TcpEventData::TextMessage(a) = data {
                             let message = (
                                 a.get_message().to_owned(), 
-                                ref_state.read().unwrap().server().unwrap().users().get(&a.get_actor()).unwrap().name().to_string()
+                                ref_state.read()
+                                    .unwrap()
+                                    .server()
+                                    .unwrap()
+                                    .users()
+                                    .get(&a.get_actor()).map(|e| e.name().to_string())
+                                    .unwrap_or(format!("Unknown user {}", a.get_actor()))
                             );
                             sender.send(Ok(Some(CommandResponse::PastMessage { message }))).is_ok()
                         } else {
@@ -634,7 +640,14 @@ pub fn handle_command(
                     None => return now!(Err(Error::Disconnected)),
                 };
                 let messages = messages.into_iter()
-                    .map(|(msg, user)| (msg, server.users().get(&user).unwrap().name().to_string())).collect();
+                    .map(|(msg, user)| (msg, server
+                        .users()
+                        .get(&user)
+                        .map(|e| e
+                            .name()
+                            .to_string())
+                            .unwrap_or(format!("Unknown user {}", user))))
+                    .collect();
                 
                 now!(Ok(Some(CommandResponse::PastMessages { messages })))
             }

--- a/mumd/src/state/channel.rs
+++ b/mumd/src/state/channel.rs
@@ -4,7 +4,7 @@ use mumble_protocol::control::msgs;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Channel {
     description: Option<String>,
     links: Vec<u32>,

--- a/mumd/src/state/server.rs
+++ b/mumd/src/state/server.rs
@@ -3,6 +3,7 @@ use crate::state::user::User;
 
 use log::*;
 use mumble_protocol::control::msgs;
+use mumlib::error::ChannelIdentifierError;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -86,6 +87,44 @@ impl Server {
 
     pub fn channels(&self) -> &HashMap<u32, Channel> {
         &self.channels
+    }
+
+    /// Takes a channel name and returns either a tuple with the channel id and a reference to the
+    /// channel struct if the channel name unambiguosly refers to a channel, or an error describing
+    /// if the channel identifier was ambigous or invalid.
+    /*/// note that doctests currently aren't run in binary crates yet (see #50784)
+    /// ```
+    /// use crate::state::channel::Channel;
+    /// let mut server = Server::new();
+    /// let channel = Channel {
+    ///     name: "Foobar".to_owned(),
+    ///     ..Default::default(),
+    /// };
+    /// server.channels.insert(0, channel.clone);
+    /// assert_eq!(server.channel_name("Foobar"), Ok((0, &channel)));
+    /// ```*/
+    pub fn channel_name(&self, channel_name: &str) -> Result<(u32, &Channel), ChannelIdentifierError> {
+        let matches = self.channels
+            .iter()
+            .map(|e| ((*e.0, e.1), e.1.path(&self.channels)))
+            .filter(|e| e.1.ends_with(channel_name))
+            .collect::<Vec<_>>();
+        Ok(match matches.len() {
+            0 => {
+                let soft_matches = self.channels
+                    .iter()
+                    .map(|e| ((*e.0, e.1), e.1.path(&self.channels).to_lowercase()))
+                    .filter(|e| e.1.ends_with(&channel_name.to_lowercase()))
+                    .collect::<Vec<_>>();
+                match soft_matches.len() {
+                    0 => return Err(ChannelIdentifierError::Invalid),
+                    1 => soft_matches.get(0).unwrap().0,
+                    _ => return Err(ChannelIdentifierError::Ambiguous),
+                }
+            }
+            1 => matches.get(0).unwrap().0,
+            _ => return Err(ChannelIdentifierError::Ambiguous),
+        })
     }
 
     pub fn host_mut(&mut self) -> &mut Option<String> {

--- a/mumd/src/state/server.rs
+++ b/mumd/src/state/server.rs
@@ -92,7 +92,7 @@ impl Server {
     /// Takes a channel name and returns either a tuple with the channel id and a reference to the
     /// channel struct if the channel name unambiguosly refers to a channel, or an error describing
     /// if the channel identifier was ambigous or invalid.
-    /*/// note that doctests currently aren't run in binary crates yet (see #50784)
+    /// note that doctests currently aren't run in binary crates yet (see #50784)
     /// ```
     /// use crate::state::channel::Channel;
     /// let mut server = Server::new();
@@ -102,7 +102,7 @@ impl Server {
     /// };
     /// server.channels.insert(0, channel.clone);
     /// assert_eq!(server.channel_name("Foobar"), Ok((0, &channel)));
-    /// ```*/
+    /// ```
     pub fn channel_name(&self, channel_name: &str) -> Result<(u32, &Channel), ChannelIdentifierError> {
         let matches = self.channels
             .iter()

--- a/mumlib/src/command.rs
+++ b/mumlib/src/command.rs
@@ -29,6 +29,7 @@ pub enum Command {
     },
     Status,
     UserVolumeSet(String, f32),
+    PastMessages,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -55,4 +56,7 @@ pub enum CommandResponse {
     Status {
         server_state: Server,
     },
+    PastMessages {
+        messages: Vec<(String, String)>,
+    }
 }

--- a/mumlib/src/command.rs
+++ b/mumlib/src/command.rs
@@ -30,6 +30,10 @@ pub enum Command {
     Status,
     UserVolumeSet(String, f32),
     PastMessages,
+    SendMessage {
+        message: String,
+        targets: Vec<MessageTarget>,
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -58,5 +62,16 @@ pub enum CommandResponse {
     },
     PastMessages {
         messages: Vec<(String, String)>,
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum MessageTarget {
+    Channel {
+        recursive: bool,
+        name: String,
+    },
+    User {
+        name: String,
     }
 }

--- a/mumlib/src/command.rs
+++ b/mumlib/src/command.rs
@@ -29,7 +29,9 @@ pub enum Command {
     },
     Status,
     UserVolumeSet(String, f32),
-    PastMessages,
+    PastMessages {
+        block: bool,
+    },
     SendMessage {
         message: String,
         targets: Vec<MessageTarget>,

--- a/mumlib/src/command.rs
+++ b/mumlib/src/command.rs
@@ -64,6 +64,9 @@ pub enum CommandResponse {
     },
     PastMessages {
         messages: Vec<(String, String)>,
+    },
+    PastMessage {
+        message: (String, String),
     }
 }
 

--- a/mumlib/src/command.rs
+++ b/mumlib/src/command.rs
@@ -62,9 +62,6 @@ pub enum CommandResponse {
     Status {
         server_state: Server,
     },
-    PastMessages {
-        messages: Vec<(String, String)>,
-    },
     PastMessage {
         message: (String, String),
     }


### PR DESCRIPTION
This PR does a lot of things. It adds support for sending and receiving messages. It also lets users wait for messages and have them printed as they come in. To support this, I had to re-engineer part of the backend, since most of the code assumed that one command=one response. I'm not sure that the way that I have done it is the best, but I think that we can see if it works and rework it later if we find out that the implementation is unworkable.

Since this PR introduces support for multiple responses to a message, we can probably implement other features that would get use from multiple responses, for example configuring noise gate thresholds (#65).