### PR TITLE
Handle invalid certs better

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,7 +23,8 @@ Added
  * Server passwords. Thanks @rbran!
  * Added support for sending and receiving text messages
  * Invalid server certificates are now rejected by default and need to be
-   explicitly allowed either per server or globally.
+   explicitly allowed either when connecting or permanently per server or
+   globally.
 
 Changed
 ~~~~~~~

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,8 @@ Added
  * --version now includes the current commit hash.
  * Server passwords. Thanks @rbran!
  * Added support for sending and receiving text messages
+ * Invalid server certificates are now rejected by default and need to be
+   explicitly allowed either per server or globally.
 
 Changed
 ~~~~~~~

--- a/documentation/mumdrc.5
+++ b/documentation/mumdrc.5
@@ -2,12 +2,12 @@
 .\"     Title: mumdrc
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.15
-.\"      Date: 2021-04-10
+.\"      Date: 2021-06-08
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MUMDRC" "5" "2021-04-10" "\ \&" "\ \&"
+.TH "MUMDRC" "5" "2021-06-08" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -35,6 +35,12 @@ This file contains persistent configuration for mumd(1). It can be written to
 using mumctl(1).
 .sp
 The following configuration values are supported:
+.sp
+accept_all_invalid_certs
+.RS 4
+Whether to connect to a server that supplies an invalid server certificate.
+This is overriden by server\-specific settings. Default false.
+.RE
 .sp
 audio.input_volume
 .RS 4
@@ -72,6 +78,13 @@ The username to connect with. (Optional)
 password
 .RS 4
 The password to supply to the server. (Optional)
+.RE
+.sp
+accept_invalid_cert
+.RS 4
+Whether to connect to this server even if it supplies an invalid server
+certificate. This overrides the global accept_all_invalid_certs if set.
+Default false.
 .RE
 .SH "AUTHORS"
 .sp

--- a/documentation/mumdrc.txt
+++ b/documentation/mumdrc.txt
@@ -14,6 +14,10 @@ using mumctl(1).
 
 The following configuration values are supported:
 
+accept_all_invalid_certs ::
+    Whether to connect to a server that supplies an invalid server certificate.
+    This is overriden by server-specific settings. Default false.
+
 audio.input_volume ::
     Default 1.0.
 
@@ -37,6 +41,11 @@ username ::
 
 password ::
     The password to supply to the server. (Optional)
+
+accept_invalid_cert ::
+    Whether to connect to this server even if it supplies an invalid server
+    certificate. This overrides the global accept_all_invalid_certs if set.
+    Default false.
 
 Authors
 -------

--- a/mumctl/src/main.rs
+++ b/mumctl/src/main.rs
@@ -582,7 +582,7 @@ fn match_server_command(server_command: Server, config: &mut Config) -> Result<(
                     port,
                     username,
                     password,
-                    accept_invalid_cert: None, //TODO
+                    accept_invalid_cert: None,
                 });
             }
         }

--- a/mumctl/src/main.rs
+++ b/mumctl/src/main.rs
@@ -527,7 +527,7 @@ fn match_server_command(server_command: Server, config: &mut Config) -> Result<(
                         "{}",
                         server
                             .accept_invalid_cert
-                            .map(|b| if b { "true" } else { "false "})
+                            .map(|b| b.to_string())
                             .ok_or(CliError::NotSet("accept_invalid_cert".to_string()))?
                     );
                 }
@@ -548,10 +548,9 @@ fn match_server_command(server_command: Server, config: &mut Config) -> Result<(
                     //TODO ask stdin if empty
                 }
                 (Some("accept_invalid_cert"), Some(value)) => {
-                    match value.as_ref() {
-                        "true" => server.accept_invalid_cert = Some(true),
-                        "false" => server.accept_invalid_cert = Some(false),
-                        v => warn!("Couldn't parse '{}' as bool", v),
+                    match value.parse() {
+                        Ok(b) => server.accept_invalid_cert = Some(b),
+                        Err(e) => warn!("{}", e)
                     }
                 }
                 (Some(_), _) => {

--- a/mumd/src/command.rs
+++ b/mumd/src/command.rs
@@ -32,16 +32,19 @@ pub async fn handle(
             &mut connection_info_sender,
         );
         match event {
-            ExecutionContext::TcpEventCallback(event, generator) => {
-                tcp_event_queue.register_callback(
-                    event,
-                    Box::new(move |e| {
-                        let response = generator(e);
-                        for response in response {
-                            response_sender.send(response).unwrap();
-                        }
-                    }),
-                );
+            ExecutionContext::TcpEventCallback(callbacks) => {
+                for (event, generator) in callbacks {
+                    let response_sender = response_sender.clone();
+                    tcp_event_queue.register_callback(
+                        event,
+                        Box::new(move |e| {
+                            let response = generator(e);
+                            for response in response {
+                                response_sender.send(response).unwrap();
+                            }
+                        }),
+                    );
+                }
             }
             ExecutionContext::TcpEventSubscriber(event, mut handler) => tcp_event_queue
                 .register_subscriber(

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -575,7 +575,7 @@ pub fn handle_command(
                     }
                 },
                 TcpEvent::Disconnected(DisconnectedReason::InvalidTls) => |_| {
-                    Box::new(iter::once(Ok(Some(CommandResponse::ServerCertReject))))
+                    Box::new(iter::once(Err(Error::ServerCertReject)))
                 }
             )
         }

--- a/mumlib/src/command.rs
+++ b/mumlib/src/command.rs
@@ -53,7 +53,6 @@ pub enum CommandResponse {
     ServerConnect {
         welcome_message: Option<String>,
     },
-    ServerCertReject,
     ServerStatus {
         version: u32,
         users: u32,

--- a/mumlib/src/command.rs
+++ b/mumlib/src/command.rs
@@ -53,6 +53,7 @@ pub enum CommandResponse {
     ServerConnect {
         welcome_message: Option<String>,
     },
+    ServerCertReject,
     ServerStatus {
         version: u32,
         users: u32,

--- a/mumlib/src/error.rs
+++ b/mumlib/src/error.rs
@@ -11,6 +11,7 @@ pub enum Error {
     InvalidServerAddr(String, u16),
     InvalidUsername(String),
     InvalidServerPassword,
+    ServerCertReject,
 }
 
 impl std::error::Error for Error {}
@@ -26,6 +27,7 @@ impl fmt::Display for Error {
             }
             Error::InvalidUsername(username) => write!(f, "Invalid username: {}", username),
             Error::InvalidServerPassword => write!(f, "Invalid server password"),
+            Error::ServerCertReject => write!(f, "Invalid server certificate"),
         }
     }
 }


### PR DESCRIPTION
Whether to accept invalid certificates or not is now handled by configuration values, both globally and per server.

One fun change is to `at!` and `ExecutionContext::TcpEventCallback`. We can now specify many different `TcpEvent`s to react to, which we use to return if the login was successful or rejected due to cert failure. We also use an `Rc<AtomicBool>` to make sure that we only call one of the supplied callbacks.