### PR TITLE
Audio output rework

### DIFF
--- a/mumd/src/audio.rs
+++ b/mumd/src/audio.rs
@@ -235,7 +235,7 @@ impl AudioOutput {
 
     pub fn play_effect(&self, effect: NotificationEvents) {
         let samples = self.sounds.get(&effect).unwrap();
-        self.client_streams.lock().unwrap().extend(None, samples);
+        self.client_streams.lock().unwrap().add_sound_effect(samples);
     }
 }
 

--- a/mumd/src/audio/input.rs
+++ b/mumd/src/audio/input.rs
@@ -29,8 +29,8 @@ pub fn callback<T: Sample>(
             buffer.extend(data.by_ref().take(buffer_size - buffer.len()));
             let encoded = transformers
                 .iter_mut()
-                .try_fold(&mut buffer[..], |acc, e| e.transform(acc))
-                .map(|buf| opus_encoder.encode_vec_float(&*buf, buffer_size).unwrap());
+                .try_fold((opus::Channels::Mono, &mut buffer[..]), |acc, e| e.transform(acc))
+                .map(|buf| opus_encoder.encode_vec_float(&*buf.1, buffer_size).unwrap());
 
             if let Some(encoded) = encoded {
                 if let Err(e) = input_sender.try_send(encoded) {

--- a/mumd/src/audio/output.rs
+++ b/mumd/src/audio/output.rs
@@ -180,14 +180,6 @@ impl DefaultAudioOutputDevice {
         let err_fn = |err| error!("An error occurred on the output audio stream: {}", err);
 
         let (output_volume_sender, output_volume_receiver) = watch::channel::<f32>(output_volume);
-        let output_channels = match output_config.channels {
-            1 => opus::Channels::Mono,
-            2 => opus::Channels::Stereo,
-            _ => {
-                warn!("Trying to output to an unsupported number of channels ({}), defaulting to mono", output_config.channels);
-                opus::Channels::Mono
-            }
-        };
 
         let output_stream = match output_supported_sample_format {
             SampleFormat::F32 => output_device.build_output_stream(
@@ -196,7 +188,6 @@ impl DefaultAudioOutputDevice {
                     Arc::clone(&client_streams),
                     output_volume_receiver,
                     user_volumes,
-                    output_channels,
                 ),
                 err_fn,
             ),
@@ -206,7 +197,6 @@ impl DefaultAudioOutputDevice {
                     Arc::clone(&client_streams),
                     output_volume_receiver,
                     user_volumes,
-                    output_channels,
                 ),
                 err_fn,
             ),
@@ -216,7 +206,6 @@ impl DefaultAudioOutputDevice {
                     Arc::clone(&client_streams),
                     output_volume_receiver,
                     user_volumes,
-                    output_channels,
                 ),
                 err_fn,
             ),
@@ -262,7 +251,6 @@ pub fn callback<T: Sample + AddAssign + SaturatingAdd + std::fmt::Display>(
     user_bufs: Arc<Mutex<ClientStream>>,
     output_volume_receiver: watch::Receiver<f32>,
     user_volumes: Arc<Mutex<HashMap<u32, (f32, bool)>>>,
-    output_channels: opus::Channels,
 ) -> impl FnMut(&mut [T], &OutputCallbackInfo) + Send + 'static {
     move |data: &mut [T], _info: &OutputCallbackInfo| {
         for sample in data.iter_mut() {

--- a/mumd/src/audio/output.rs
+++ b/mumd/src/audio/output.rs
@@ -180,6 +180,14 @@ impl DefaultAudioOutputDevice {
         let err_fn = |err| error!("An error occurred on the output audio stream: {}", err);
 
         let (output_volume_sender, output_volume_receiver) = watch::channel::<f32>(output_volume);
+        let output_channels = match output_config.channels {
+            1 => opus::Channels::Mono,
+            2 => opus::Channels::Stereo,
+            _ => {
+                warn!("Trying to output to an unsupported number of channels ({}), defaulting to mono", output_config.channels);
+                opus::Channels::Mono
+            }
+        };
 
         let output_stream = match output_supported_sample_format {
             SampleFormat::F32 => output_device.build_output_stream(
@@ -188,6 +196,7 @@ impl DefaultAudioOutputDevice {
                     Arc::clone(&client_streams),
                     output_volume_receiver,
                     user_volumes,
+                    output_channels,
                 ),
                 err_fn,
             ),
@@ -197,6 +206,7 @@ impl DefaultAudioOutputDevice {
                     Arc::clone(&client_streams),
                     output_volume_receiver,
                     user_volumes,
+                    output_channels,
                 ),
                 err_fn,
             ),
@@ -206,6 +216,7 @@ impl DefaultAudioOutputDevice {
                     Arc::clone(&client_streams),
                     output_volume_receiver,
                     user_volumes,
+                    output_channels,
                 ),
                 err_fn,
             ),

--- a/mumd/src/audio/output.rs
+++ b/mumd/src/audio/output.rs
@@ -92,7 +92,6 @@ impl ClientStream {
     pub fn decode_packet(&mut self, client: ClientStreamKey, payload: VoicePacketPayload) {
         match payload {
             VoicePacketPayload::Opus(bytes, _eot) => {
-                debug!("{:?} {:?}", self.output_channels, opus::packet::get_nb_channels(&bytes));
                 self.get_client(client).store_packet(bytes);
             }
             _ => {

--- a/mumd/src/audio/transformers.rs
+++ b/mumd/src/audio/transformers.rs
@@ -2,7 +2,7 @@
 pub trait Transformer {
     /// Do the transform. Returning `None` is interpreted as "the buffer is unwanted".
     /// The implementor is free to modify the buffer however it wants to.
-    fn transform<'a>(&mut self, buf: &'a mut [f32]) -> Option<&'a mut [f32]>;
+    fn transform<'a>(&mut self, buf: (opus::Channels, &'a mut [f32])) -> Option<(opus::Channels, &'a mut [f32])>;
 }
 
 /// A struct representing a noise gate transform.
@@ -25,7 +25,7 @@ impl NoiseGate {
 }
 
 impl Transformer for NoiseGate {
-    fn transform<'a>(&mut self, buf: &'a mut [f32]) -> Option<&'a mut [f32]> {
+    fn transform<'a>(&mut self, (channels, buf): (opus::Channels, &'a mut [f32])) -> Option<(opus::Channels, &'a mut [f32])> {
         const MUTE_PERCENTAGE: f32 = 0.1;
 
         let max = buf.iter().map(|e| e.abs()).max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap();
@@ -43,7 +43,7 @@ impl Transformer for NoiseGate {
         if self.open == 0 {
             None
         } else {
-            Some(buf)
+            Some((channels, buf))
         }
     }
 }


### PR DESCRIPTION
This PR restructures audio output and allows for both outputting both mono and stereo sound. I have yet to document most new functions. Something else that might be worth adding to this PR is a way to add transformers to the output as well, but its not strictly necessary.