### PR TITLE
Send notifications on new thread

### DIFF
--- a/mum/src/notifications.rs
+++ b/mum/src/notifications.rs
@@ -1,25 +1,34 @@
-#[cfg(feature = "notifications")]
-use log::*;
-
+/// Try to initialize the notification daemon.
+///
+/// Does nothing if compiled without notification support.
 pub fn init() {
     #[cfg(feature = "notifications")]
     if let Err(e) = libnotify::init("mumd") {
-        warn!("Unable to initialize notifications: {}", e);
+        log::warn!("Unable to initialize notifications: {}", e);
     }
 }
 
 #[cfg(feature = "notifications")]
-pub fn send(msg: String) -> Option<bool> {
-    match libnotify::Notification::new("mumd", Some(msg.as_str()), None).show() {
-        Ok(_) => Some(true),
-        Err(e) => {
-            warn!("Unable to send notification: {}", e);
-            Some(false)
+/// Send a notification non-blocking, returning a JoinHandle that resolves to
+/// whether the notification was sent or not.
+///
+/// The notification is sent on its own thread since a timeout otherwise might
+/// block for several seconds.
+///
+/// None is returned iff the program was compiled without notification support.
+pub fn send(msg: String) -> Option<std::thread::JoinHandle<bool>> {
+    Some(std::thread::spawn(move || {
+        let status = libnotify::Notification::new("mumd", Some(msg.as_str()), None).show();
+        if let Err(e) = &status {
+            log::warn!("Unable to send notification: {}", e);
         }
-    }
+        status.is_ok()
+    }))
 }
 
 #[cfg(not(feature = "notifications"))]
-pub fn send(_: String) -> Option<bool> {
+/// Send a notification. Without the `notifications`-feature, this will never do
+/// anything and always return None.
+pub fn send(_: String) -> Option<std::thread::JoinHandle<bool>> {
     None
 }


### PR DESCRIPTION
Apparently, sending notifications is a blocking operation. This is an issue if the sending needs to timeout, in which case the entire executor is blocked.